### PR TITLE
Revert "Ensure scripts are not executed"

### DIFF
--- a/packages/jsx2/src/diff/create-tree.ts
+++ b/packages/jsx2/src/diff/create-tree.ts
@@ -72,7 +72,7 @@ export function createChild(
   const { type, props, ref } = renderable;
   if (typeof type === 'string') {
     if (type === 'svg') namespace = NS.SVG;
-    const el = createElementNS(namespace, type);
+    const el = document.createElementNS(nsToNode(namespace), type) as HTMLElement | SVGElement;
     const childNs = childSpace(namespace, type);
     setOnNode(el, f);
     f.dom = el;
@@ -101,16 +101,4 @@ export function createChild(
   createChild(coerceRenderable(component.render(props)), f, null, namespace, refs, layoutEffects);
   deferRef(refs, component, null, renderable.ref);
   return f;
-}
-
-function createElementNS(namespace: NS, name: string): HTMLElement | SVGElement {
-  if (namespace !== NS.HTML) {
-    return document.createElementNS(nsToNode(namespace), name) as SVGElement;
-  }
-  if (name === 'script') {
-    const c = document.createElement('div');
-    c.innerHTML = '<script>';
-    return c.removeChild(c.firstChild as HTMLScriptElement);
-  }
-  return document.createElement(name);
 }

--- a/packages/jsx2/test/diff/create-tree.ts
+++ b/packages/jsx2/test/diff/create-tree.ts
@@ -148,31 +148,6 @@ describe('createTree', () => {
       expect(firstChild.namespaceURI).toBe('http://www.w3.org/1999/xhtml');
     });
 
-    it('does not execute script contents', () => {
-      // Use the real body, because it will execute scripts
-      const { body } = document;
-      let err: Error | null = null;
-      function onError(event: ErrorEvent) {
-        err = event.error;
-      }
-      window.addEventListener('error', onError);
-
-      try {
-        const createElementSpy = jest.spyOn(document, 'createElement');
-        const createElementNSSpy = jest.spyOn(document, 'createElementNS');
-        create(createElement('script', null, 'throw new Error("executed");'), body);
-
-        const firstChild = body.firstChild!;
-        expectElement(firstChild, 'script');
-        expect(err).toBe(null);
-        expect(createElementSpy).not.toHaveBeenCalledWith('script');
-        expect(createElementNSSpy).not.toHaveBeenCalledWith(expect.anything(), 'script');
-      } finally {
-        body.innerHTML = '';
-        window.removeEventListener('error', onError);
-      }
-    });
-
     it('renders props', () => {
       const body = document.createElement('body');
 


### PR DESCRIPTION
Reverts jridgewell/jsx2#91

The only way to create a `<script>` node is to have direct access to the `jsx2.createElement` function, there is no security vulnerability. This is because our [`constructor === undefined`](https://github.com/jridgewell/jsx2/blob/c69e73f6ddb7a4d619023ff3d89c2e82bcc6bfda/packages/jsx2/src/create-element.ts#L77) check protects against JSON injections.