### PR TITLE
Optimize insert and reorder cases

### DIFF
--- a/packages/jsx2/src/diff/diff-tree.ts
+++ b/packages/jsx2/src/diff/diff-tree.ts
@@ -15,7 +15,7 @@ import { isValidElement } from '../create-element';
 import { clone } from '../fiber/clone';
 import { getContainer } from '../fiber/get-container';
 import { getNextSibling } from '../fiber/get-next-sibling';
-import { insert } from '../fiber/insert';
+import { insert, reorder } from '../fiber/insert';
 import { mark } from '../fiber/mark';
 import { remove } from '../fiber/remove';
 import { replace } from '../fiber/replace';
@@ -191,7 +191,7 @@ function renderArray(
         if (current === already) {
           current = current.next;
         } else {
-          insert(cloned, container, before);
+          reorder(cloned, container, before);
         }
 
         const f = diffChild(cloned, r, old, last, container, refs, layoutEffects);

--- a/packages/jsx2/src/fiber/insert.ts
+++ b/packages/jsx2/src/fiber/insert.ts
@@ -3,29 +3,60 @@ import type { Fiber } from '.';
 import { assert } from '../util/assert';
 
 export function insert(fiber: Fiber, container: Node, before: null | Node): void {
-  debug: assert(
-    before === null || before.parentNode === container,
-    'before node must be child of container',
-  );
-  insertRange(fiber, fiber.next, container, before);
+  debug: {
+    assert(
+      before === null || before.parentNode === container,
+      'before node must be child of container',
+    );
+    verifyFiberMountedInContianer(fiber, fiber.next, null);
+  }
+  insertRange(fiber, fiber.next, container, before, false);
 }
 
-function insertRange(fiber: Fiber, end: null | Fiber, container: Node, before: null | Node): void {
+export function reorder(fiber: Fiber, container: Node, before: null | Node): void {
+  debug: {
+    assert(
+      before === null || before.parentNode === container,
+      'before node must be child of container',
+    );
+    verifyFiberMountedInContianer(fiber, fiber.next, container);
+  }
+  insertRange(fiber, fiber.next, container, before, true);
+}
+
+function insertRange(
+  fiber: Fiber,
+  end: null | Fiber,
+  container: Node,
+  before: null | Node,
+  reorder: boolean,
+): void {
   let current: null | Fiber = fiber;
   do {
     const { dom, data, child } = current!;
     if (dom !== null && dom !== data) {
-      debug: assert(
-        dom.parentNode === null || dom.parentNode === container,
-        'fiber must not already be mounted, or be mounted as a direct child of container',
-      );
-
-      if (child) insertRange(child, null, dom, null);
+      if (!reorder && child) insertRange(child, null, dom, null, reorder);
       container.insertBefore(dom, before);
     } else if (child) {
-      insertRange(child, null, container, before);
+      insertRange(child, null, container, before, reorder);
     }
 
     current = current!.next;
+  } while (current !== end);
+}
+
+function verifyFiberMountedInContianer(fiber: Fiber, end: Fiber | null, container: Node | null) {
+  let current: null | Fiber = fiber;
+  do {
+    assert(current !== null);
+    const { data, dom, child } = current;
+    if (dom && dom !== data) {
+      assert(
+        dom.parentNode === container,
+        'fiber must be mounted inside container to be reordered',
+      );
+    }
+    if (child) verifyFiberMountedInContianer(child, null, container && dom ? dom : null);
+    current = current.next;
   } while (current !== end);
 }


### PR DESCRIPTION
Before, reordering would recursively reorder inside elemnts, causing excess `removeChild` and `insertBefore` calls